### PR TITLE
update transitiontime

### DIFF
--- a/content/api/lights.md
+++ b/content/api/lights.md
@@ -103,7 +103,7 @@ alert
 : `select` flashes light once, `lselect` flashes repeatedly for 10 seconds.
 
 transitiontime
-: time for transition in centiseconds.
+: time for transition in deciseconds.
 
 ### Input
 


### PR DESCRIPTION
Testing with my Philips Hue system shows transitiontime to be in deciseconds, not centiseconds.  Bridge = Philips BSB001, swversion = 01024156. Lights are Philips LWB004 (Hue Lux) swversion = 66012040.
